### PR TITLE
Allow Promise usage && add read/write stream options

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ $ npm install xml2csv --save
 
 ## <a name="usage"></a>Usage
 
+### Use with callback
+
 ```javascript
 const xml2csv = require('xml2csv')
 
@@ -42,7 +44,58 @@ xml2csv(
 )
 
 ```
-Input: 
+
+### Use with Promises
+
+```javascript
+const xml2csv = require('xml2csv')
+
+xml2csv(
+  {
+    xmlPath: 'path/to/file.xml',
+    csvPath: 'path/to/file.csv',
+    rootXMLElement: 'Record',
+    headerMap: [
+      ['Name', 'name', 'string'],
+      ['Age', 'age', 'integer'],
+      ['Gender', 'gender', 'string'],
+      ['Brother', 'brother', 'string', 'Siblings'],
+      ['Sister', 'sister', 'string', 'Siblings']
+    ]
+  },
+)
+.then(console.log)
+.catch(console.log);
+```
+
+### Use with async/await
+
+```javascript
+const xml2csv = require('xml2csv')
+
+try {
+  const res = await xml2csv(
+    {
+      xmlPath: 'path/to/file.xml',
+      csvPath: 'path/to/file.csv',
+      rootXMLElement: 'Record',
+      headerMap: [
+        ['Name', 'name', 'string'],
+        ['Age', 'age', 'integer'],
+        ['Gender', 'gender', 'string'],
+        ['Brother', 'brother', 'string', 'Siblings'],
+        ['Sister', 'sister', 'string', 'Siblings']
+      ]
+    },
+  )
+  console.log(res)
+} catch(err) {
+  console.log(err)
+}
+```
+
+Input:
+
 ```
 <People>
     <Person>
@@ -75,8 +128,10 @@ name, age, gender, brother, sister
 
 | Property              | Type      | Notes  |
 | --------              | ----      | -----  |
-| `xmlPath`             | `string`  | A path to the xml input file.
-| `csvPath`             | `string`  | The path and filename of the generated CSV output file (note that any intermediate folders will be created).
+| `xmlPath`             | `string`  | A path to the xml input file. Cannot be provide with `xmlStream` property.
+| `xmlStream`           | `fs.ReadStream`  | A readable stream from an xml file. Cannot be provide with `xmlPath` property.
+| `csvPath`             | `string`  | The path and filename of the generated CSV output file (note that any intermediate folders will be created). Cannot be provide with `csvStream` property.
+| `csvStream`           | `fs.WriteStream`  | A writeable stream for the generated CSV data. Cannot be provide with `csvPath` property.
 | `rootXMLElement`      | `string`  | The XML root tag for each record, element to split records on in XML file.
 | `headerMap`           | `[array]` | See the [Header Map](#headerMap) section for more details.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,96 +1,103 @@
 'use strict'
 
-const fs = require('fs')
+const fs = require('fs-extra')
 const sax = require('sax')
 const dottie = require('dottie')
 const _ = require('lodash')
-const path = require('path')
-const mkdirp = require('mkdirp')
 const debug = require('debug')
 
 const endOfLine = require('os').EOL
 const comma = ','
 
-module.exports = function (options, callback) {
-  const outputPath = path.dirname(options.csvPath)
-  mkdirp(outputPath, (err) => {
-    if (err) {
-      debug(err)
-      callback(err)
-    } else {
-      const source = fs.createReadStream(options.xmlPath)
-      const output = fs.createWriteStream(options.csvPath)
-      const saxStream = sax.createStream(true)
+const main = function (options, callback) {
+  try {
+    if ((options.xmlStream && options.xmlPath) || (!options.xmlStream && !options.xmlPath)) {
+      throw (new Error('Please provide either xmlStream or xmlPath'))
+    }
+    if ((options.csvStream && options.csvPath) || (!options.csvStream && !options.csvPath)) {
+      throw (new Error('Please provide either csvStream or csvPath'))
+    }
 
-      saxStream.on('error', function () {
-        console.log('ERR')
-      })
+    if (options.csvPath) {
+      fs.ensureFileSync(options.csvPath)
+    }
 
-      let count = 0
-      let accepting = false
-      let currentObj
-      let pathParts = []
-      let pathPartsString
+    const source = options.xmlStream || fs.createReadStream(options.xmlPath)
+    const output = options.csvStream || fs.createWriteStream(options.csvPath)
 
-      writeHeadersToFile(options.headerMap, output)
+    const saxStream = sax.createStream(true)
 
-      saxStream.on(
-        'opentag',
-        function (t) {
-          if (t.name === options.rootXMLElement) {
-            accepting = true
-            pathParts = []
-            currentObj = {}
-          } else {
-            if (accepting) {
-              pathParts.push(t.name)
-              pathPartsString = pathParts.join('.')
-            }
+    saxStream.on('error', function (err) {
+      console.log(err)
+    })
+
+    let count = 0
+    let accepting = false
+    let currentObj
+    let pathParts = []
+    let pathPartsString
+
+    writeHeadersToFile(options.headerMap, output)
+
+    saxStream.on(
+      'opentag',
+      function (t) {
+        if (t.name === options.rootXMLElement) {
+          accepting = true
+          pathParts = []
+          currentObj = {}
+        } else {
+          if (accepting) {
+            pathParts.push(t.name)
+            pathPartsString = pathParts.join('.')
           }
         }
-      )
+      }
+    )
 
-      saxStream.on(
-        'text',
-        function (text) {
-          if (accepting) {
-            if (text.trim() !== '\n' && text.trim() !== '') {
-              dottie.set(currentObj, pathPartsString, text)
-            }
-          }
-        }
-      )
-
-      saxStream.on(
-        'cdata',
-        function (text) {
-          if (accepting) {
+    saxStream.on(
+      'text',
+      function (text) {
+        if (accepting) {
+          if (text.trim() !== '\n' && text.trim() !== '') {
             dottie.set(currentObj, pathPartsString, text)
           }
         }
-      )
+      }
+    )
 
-      saxStream.on(
-        'closetag',
-        function (tagName) {
-          if (tagName === options.rootXMLElement) {
-            writeRecordToFile(currentObj, options.headerMap, output)
-            count++
-            accepting = false
-            currentObj = {}
-          } else {
-            pathParts.pop()
-          }
+    saxStream.on(
+      'cdata',
+      function (text) {
+        if (accepting) {
+          dottie.set(currentObj, pathPartsString, text)
         }
-      )
+      }
+    )
 
-      saxStream.on('end', function () {
-        callback(null, { count: count })
-      })
+    saxStream.on(
+      'closetag',
+      function (tagName) {
+        if (tagName === options.rootXMLElement) {
+          writeRecordToFile(currentObj, options.headerMap, output)
+          count++
+          accepting = false
+          currentObj = {}
+        } else {
+          pathParts.pop()
+        }
+      }
+    )
 
-      source.pipe(saxStream)
-    }
-  })
+    saxStream.on('end', function () {
+      callback(null, { count: count })
+    })
+
+    source.pipe(saxStream)
+  } catch (err) {
+    debug(err)
+    callback(err)
+  }
 }
 
 function writeHeadersToFile (headerMap, outputStream) {
@@ -120,4 +127,19 @@ function writeField (field, type, separator) {
   const quote = type === 'string' ? '"' : ''
 
   return `${quote}${field}${quote}${separator}`
+}
+
+module.exports = function (options, callback) {
+  if (typeof callback === 'function') {
+    return main(options, callback)
+  }
+  return new Promise((resolve, reject) => {
+    return main(options, (err, res) => {
+      if (err) {
+        reject(err)
+      } else {
+        resolve(res)
+      }
+    })
+  })
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -126,7 +126,7 @@ function writeField (field, type, separator) {
 
   const quote = type === 'string' ? '"' : ''
 
-  return `${quote}${field}${quote}${separator}`
+  return `${quote}${field.replace(/"/g, '""')}${quote}${separator}`
 }
 
 module.exports = function (options, callback) {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "dottie": "2.0.2",
     "fs-extra": "^8.1.0",
     "lodash": "4.17.15",
-    "mkdirp": "0.5.1",
     "sax": "1.2.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "debug": "4.1.1",
     "dottie": "2.0.2",
+    "fs-extra": "^8.1.0",
     "lodash": "4.17.15",
     "mkdirp": "0.5.1",
     "sax": "1.2.4"

--- a/test/expected/weirdCases.csv
+++ b/test/expected/weirdCases.csv
@@ -1,0 +1,11 @@
+first,second
+"This sentence has ""double quotes""","control"
+"This sentence has , comma","control"
+"4""2","control"
+"4,2","control"
+"""42","control"
+",42","control"
+"42","control"
+,"control"
+"42",
+,

--- a/test/fixtures/weirdCases.xml
+++ b/test/fixtures/weirdCases.xml
@@ -1,0 +1,38 @@
+<Weird>
+  <Case>
+    <First>This sentence has "double quotes"</First>
+    <Second>control</Second>
+  </Case>
+  <Case>
+    <First>This sentence has , comma</First>
+    <Second>control</Second>
+  </Case>
+  <Case>
+    <First>4"2</First>
+    <Second>control</Second>
+  </Case>
+  <Case>
+    <First>4,2</First>
+    <Second>control</Second>
+  </Case>
+  <Case>
+    <First>"42</First>
+    <Second>control</Second>
+  </Case>
+  <Case>
+    <First>,42</First>
+    <Second>control</Second>
+  </Case>
+  <Case>
+    <First>42</First>
+    <Second>control</Second>
+  </Case>
+  <Case>
+    <Second>control</Second>
+  </Case>
+  <Case>
+    <First>42</First>
+  </Case>
+  <Case>
+  </Case>
+</Weird>

--- a/test/test.js
+++ b/test/test.js
@@ -60,4 +60,25 @@ describe('Run some basic tests', function () {
 
     expect(output).to.eql(expected)
   })
+
+  it('should convert the XML file to a CSV file with particular cases', async function () {
+    const outputFile = path.resolve(__dirname, 'output', 'weirdCases.csv')
+    const expectedFile = path.resolve(__dirname, 'expected', 'weirdCases.csv')
+
+    const res = await xml2csv({
+      xmlPath: path.resolve(__dirname, 'fixtures', 'weirdCases.xml'),
+      csvPath: outputFile,
+      rootXMLElement: 'Case',
+      headerMap: [
+        ['First', 'first', 'string'],
+        ['Second', 'second', 'string']
+      ]
+    })
+
+    expect(res).to.deep.equal({ count: 10 })
+    const output = fs.readFileSync(outputFile, { encoding: 'utf8' }).split('\n')
+    const expected = fs.readFileSync(expectedFile, { encoding: 'utf8' }).split('\n')
+
+    expect(output).to.eql(expected)
+  })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -6,7 +6,7 @@ const expect = require('chai').expect
 const xml2csv = require('./../lib')
 
 describe('Run some basic tests', function () {
-  it('should convert the XML file to a CSV file', function (done) {
+  it('should convert the XML file to a CSV file with callback', function (done) {
     const outputFile = path.resolve(__dirname, 'output', 'simpsons.csv')
     const expectedFile = path.resolve(__dirname, 'expected', 'simpsons.csv')
 
@@ -23,9 +23,10 @@ describe('Run some basic tests', function () {
           ['Sister', 'sister', 'string', 'Siblings']
         ]
       },
-      function (err) {
+      function (err, res) {
         if (err) return done(err)
 
+        expect(res).to.deep.equal({ count: 4 })
         const output = fs.readFileSync(outputFile, { encoding: 'utf8' }).split('\n')
         const expected = fs.readFileSync(expectedFile, { encoding: 'utf8' }).split('\n')
 
@@ -34,5 +35,29 @@ describe('Run some basic tests', function () {
         done()
       }
     )
+  })
+
+  it('should convert the XML file to a CSV file with Promise', async function () {
+    const outputFile = path.resolve(__dirname, 'output', 'simpsons.csv')
+    const expectedFile = path.resolve(__dirname, 'expected', 'simpsons.csv')
+
+    const res = await xml2csv({
+      xmlPath: path.resolve(__dirname, 'fixtures', 'simpsons.xml'),
+      csvPath: outputFile,
+      rootXMLElement: 'Person',
+      headerMap: [
+        ['Name', 'name', 'string'],
+        ['Age', 'age', 'integer'],
+        ['Gender', 'gender', 'string'],
+        ['Brother', 'brother', 'string', 'Siblings'],
+        ['Sister', 'sister', 'string', 'Siblings']
+      ]
+    })
+
+    expect(res).to.deep.equal({ count: 4 })
+    const output = fs.readFileSync(outputFile, { encoding: 'utf8' }).split('\n')
+    const expected = fs.readFileSync(expectedFile, { encoding: 'utf8' }).split('\n')
+
+    expect(output).to.eql(expected)
   })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -1,11 +1,11 @@
 /* eslint-env mocha */
 
 const path = require('path')
-const fs = require('fs')
+const fs = require('fs-extra')
 const expect = require('chai').expect
 const xml2csv = require('./../lib')
 
-describe('Run some basic tests', function () {
+describe('Run integration tests', function () {
   it('should convert the XML file to a CSV file with callback', function (done) {
     const outputFile = path.resolve(__dirname, 'output', 'simpsons.csv')
     const expectedFile = path.resolve(__dirname, 'expected', 'simpsons.csv')
@@ -37,13 +37,37 @@ describe('Run some basic tests', function () {
     )
   })
 
-  it('should convert the XML file to a CSV file with Promise', async function () {
+  it('should convert the XML file to a CSV file with async/await', async function () {
     const outputFile = path.resolve(__dirname, 'output', 'simpsons.csv')
     const expectedFile = path.resolve(__dirname, 'expected', 'simpsons.csv')
 
     const res = await xml2csv({
       xmlPath: path.resolve(__dirname, 'fixtures', 'simpsons.xml'),
       csvPath: outputFile,
+      rootXMLElement: 'Person',
+      headerMap: [
+        ['Name', 'name', 'string'],
+        ['Age', 'age', 'integer'],
+        ['Gender', 'gender', 'string'],
+        ['Brother', 'brother', 'string', 'Siblings'],
+        ['Sister', 'sister', 'string', 'Siblings']
+      ]
+    })
+
+    expect(res).to.deep.equal({ count: 4 })
+    const output = fs.readFileSync(outputFile, { encoding: 'utf8' }).split('\n')
+    const expected = fs.readFileSync(expectedFile, { encoding: 'utf8' }).split('\n')
+
+    expect(output).to.eql(expected)
+  })
+
+  it('should convert the XML file to a CSV file with stream', async function () {
+    const outputFile = path.resolve(__dirname, 'output', 'simpsons.csv')
+    const expectedFile = path.resolve(__dirname, 'expected', 'simpsons.csv')
+    fs.ensureFileSync(outputFile)
+    const res = await xml2csv({
+      xmlStream: fs.createReadStream(path.resolve(__dirname, 'fixtures', 'simpsons.xml')),
+      csvStream: fs.createWriteStream(outputFile),
       rootXMLElement: 'Person',
       headerMap: [
         ['Name', 'name', 'string'],
@@ -80,5 +104,99 @@ describe('Run some basic tests', function () {
     const expected = fs.readFileSync(expectedFile, { encoding: 'utf8' }).split('\n')
 
     expect(output).to.eql(expected)
+  })
+})
+
+describe('Run unit tests', () => {
+  it('Should fail if xmlStream and xmlPath options are provided', async function () {
+    try {
+      const input = path.resolve(__dirname, 'fixtures', 'simpsons.xml')
+      const output = path.resolve(__dirname, 'output', 'weirdCases.csv')
+
+      await xml2csv({
+        xmlPath: input,
+        xmlStream: fs.createReadStream(input),
+        csvPath: output,
+        rootXMLElement: 'Person',
+        headerMap: [
+          ['Name', 'name', 'string'],
+          ['Age', 'age', 'integer'],
+          ['Gender', 'gender', 'string'],
+          ['Brother', 'brother', 'string', 'Siblings'],
+          ['Sister', 'sister', 'string', 'Siblings']
+        ]
+      })
+    } catch (err) {
+      expect(err.message).to.equal('Please provide either xmlStream or xmlPath')
+      return
+    }
+    throw (new Error('Should not succeed'))
+  })
+
+  it('Should fail if none of xmlStream and xmlPath options are provided', async function () {
+    try {
+      await xml2csv({
+        csvPath: 'output.csv',
+        rootXMLElement: 'Person',
+        headerMap: [
+          ['Name', 'name', 'string'],
+          ['Age', 'age', 'integer'],
+          ['Gender', 'gender', 'string'],
+          ['Brother', 'brother', 'string', 'Siblings'],
+          ['Sister', 'sister', 'string', 'Siblings']
+        ]
+      })
+    } catch (err) {
+      expect(err.message).to.equal('Please provide either xmlStream or xmlPath')
+      return
+    }
+    throw (new Error('Should not succeed'))
+  })
+
+  it('Should fail if csvStream and csvPath options are provided', async function () {
+    try {
+      const input = path.resolve(__dirname, 'fixtures', 'simpsons.xml')
+      const output = path.resolve(__dirname, 'output', 'weirdCases.csv')
+
+      await xml2csv({
+        xmlPath: input,
+        csvPath: output,
+        csvStream: fs.createWriteStream(output),
+        rootXMLElement: 'Person',
+        headerMap: [
+          ['Name', 'name', 'string'],
+          ['Age', 'age', 'integer'],
+          ['Gender', 'gender', 'string'],
+          ['Brother', 'brother', 'string', 'Siblings'],
+          ['Sister', 'sister', 'string', 'Siblings']
+        ]
+      })
+    } catch (err) {
+      expect(err.message).to.equal('Please provide either csvStream or csvPath')
+      return
+    }
+    throw (new Error('Should not succeed'))
+  })
+
+  it('Should fail if none of csvStream and csvPath options are provided', async function () {
+    try {
+      const input = path.resolve(__dirname, 'fixtures', 'simpsons.xml')
+
+      await xml2csv({
+        xmlPath: input,
+        rootXMLElement: 'Person',
+        headerMap: [
+          ['Name', 'name', 'string'],
+          ['Age', 'age', 'integer'],
+          ['Gender', 'gender', 'string'],
+          ['Brother', 'brother', 'string', 'Siblings'],
+          ['Sister', 'sister', 'string', 'Siblings']
+        ]
+      })
+    } catch (err) {
+      expect(err.message).to.equal('Please provide either csvStream or csvPath')
+      return
+    }
+    throw (new Error('Should not succeed'))
   })
 })


### PR DESCRIPTION
- Add promise and async/await support
- Support input and output stream instead of file path
- Escape double quotes as defined by [rfc4180](https://tools.ietf.org/html/rfc4180#section-2)
- Add tests