### PR TITLE
Correctly parse weird xml files with wrongly place text

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ name, age, gender, brother, sister
 | `csvStream`           | `fs.WriteStream`  | A writeable stream for the generated CSV data. Cannot be provide with `csvPath` property.
 | `rootXMLElement`      | `string`  | The XML root tag for each record, element to split records on in XML file.
 | `headerMap`           | `[array]` | See the [Header Map](#headerMap) section for more details.
+| `strict`              | `[boolean]` | Should the sax parser run in strict mode ? Defaults to `true`.
 
 ### <a name="headerMap"></a>options.headerMap
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -59,7 +59,7 @@ const main = function (options, callback) {
       'text',
       function (text) {
         if (accepting) {
-          if (text.trim() !== '\n' && text.trim() !== '') {
+          if (text.trim() !== '\n' && text.trim() !== '' && (pathPartsString || '').length > 0) {
             dottie.set(currentObj, pathPartsString, text)
           }
         }
@@ -69,7 +69,7 @@ const main = function (options, callback) {
     saxStream.on(
       'cdata',
       function (text) {
-        if (accepting) {
+        if (accepting && (pathPartsString || '').length > 0) {
           dottie.set(currentObj, pathPartsString, text)
         }
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,9 @@ const main = function (options, callback) {
     if ((options.csvStream && options.csvPath) || (!options.csvStream && !options.csvPath)) {
       throw (new Error('Please provide either csvStream or csvPath'))
     }
+    if (options.strict !== false) {
+      options.strict = true
+    }
 
     if (options.csvPath) {
       fs.ensureFileSync(options.csvPath)
@@ -25,7 +28,7 @@ const main = function (options, callback) {
     const source = options.xmlStream || fs.createReadStream(options.xmlPath)
     const output = options.csvStream || fs.createWriteStream(options.csvPath)
 
-    const saxStream = sax.createStream(true)
+    const saxStream = sax.createStream(options.strict)
 
     saxStream.on('error', function (err) {
       console.log(err)

--- a/test/expected/wronglyPlaced.csv
+++ b/test/expected/wronglyPlaced.csv
@@ -1,0 +1,2 @@
+first,second
+"OK 1","OK 2"

--- a/test/fixtures/wronglyPlaced.xml
+++ b/test/fixtures/wronglyPlaced.xml
@@ -1,0 +1,6 @@
+<Weird>lkezjflk
+  <Case>weird text at wrong place !
+    <First>OK 1</First>
+    <Second>OK 2</Second>
+  </Case>
+</Weird>

--- a/test/test.js
+++ b/test/test.js
@@ -8,10 +8,12 @@ const xml2csv = require('./../lib')
 describe('Run integration tests', function () {
   const simpsonsOutput = path.resolve(__dirname, 'output', 'simpsons.csv')
   const weirdOutput = path.resolve(__dirname, 'output', 'weirdCases.csv')
+  const wronglyPlacedOutput = path.resolve(__dirname, 'output', 'wronglyPlaced.csv')
 
   beforeEach(() => {
     fs.removeSync(simpsonsOutput)
     fs.removeSync(weirdOutput)
+    fs.removeSync(wronglyPlacedOutput)
   })
 
   it('should convert the XML file to a CSV file with callback', function (done) {
@@ -108,6 +110,26 @@ describe('Run integration tests', function () {
 
     expect(res).to.deep.equal({ count: 10 })
     const output = fs.readFileSync(weirdOutput, { encoding: 'utf8' }).split('\n')
+    const expected = fs.readFileSync(expectedFile, { encoding: 'utf8' }).split('\n')
+
+    expect(output).to.eql(expected)
+  })
+
+  it('should convert the XML file to a CSV ignoring weird texts at wrong place', async function () {
+    const expectedFile = path.resolve(__dirname, 'expected', 'wronglyPlaced.csv')
+
+    const res = await xml2csv({
+      xmlPath: path.resolve(__dirname, 'fixtures', 'wronglyPlaced.xml'),
+      csvPath: wronglyPlacedOutput,
+      rootXMLElement: 'Case',
+      headerMap: [
+        ['First', 'first', 'string'],
+        ['Second', 'second', 'string']
+      ]
+    })
+
+    expect(res).to.deep.equal({ count: 1 })
+    const output = fs.readFileSync(wronglyPlacedOutput, { encoding: 'utf8' }).split('\n')
     const expected = fs.readFileSync(expectedFile, { encoding: 'utf8' }).split('\n')
 
     expect(output).to.eql(expected)


### PR DESCRIPTION
Hello !

I tried to parse a weird xml file having text inside the main item, something like : 
```
<Weird>
  <Case>weird text at wrong place !
    <First>OK 1</First>
    <Second>OK 2</Second>
  </Case>
</Weird>
```

This breaks as the library tries to use `dottie.set(currentObj, pathPartsString, text)` with `pathPartsString == null` .

This PR fixes this and add new tests.

It also adds the ability to run sax in non strict mode.